### PR TITLE
Убираем лишние вызовы locale.setlocale(locale.LC_ALL, '')

### DIFF
--- a/snoop.py
+++ b/snoop.py
@@ -433,7 +433,6 @@ def update_snoop():
 нажмите 'y' """))
     if upd == "y":
         if sys.platform == 'win32':
-            locale.setlocale(locale.LC_ALL, '')
             print(Fore.RED + "Функция обновления Snoop требует установки <Git> на OS Windows")
             os.startfile("update.bat")
         else:
@@ -560,7 +559,6 @@ def main():
 # Опция сортировки.
     if args.sort:
         if sys.platform == 'win32':
-            locale.setlocale(locale.LC_ALL, '')
             subprocess.run(["python", "site_list.py"])
         else:
             subprocess.run(["python3", "site_list.py"])


### PR DESCRIPTION
В самом начале программы проверяется if sys.platform == 'win32' и если программа запущена под windows, то вызывается locale.setlocale(locale.LC_ALL, '').
Поэтому ниже, в функциях update_snoop() и main() в ветвях if sys.platform == 'win32' два вызова locale.setlocale(locale.LC_ALL, '') уже не нужны.

(извините, это моё первое знакомство с github и первая попытка сделать pull request, возможно я что-то делаю не так)
