### PR TITLE
Remove xrho.com

### DIFF
--- a/domainlist.txt
+++ b/domainlist.txt
@@ -9809,7 +9809,6 @@ Valid_emails
 @xoxox.cc
 @xperiae5.com
 @xpressmail.zzn.com
-@xrho.com
 @xs4all.nl
 @xsecurity.org
 @xsmail.com


### PR DESCRIPTION
Not a disposable email domain